### PR TITLE
Sanitized update/render/handler priorities

### DIFF
--- a/Hero.py
+++ b/Hero.py
@@ -16,9 +16,9 @@ class Hero:
 	""" and other features of the character for worldmap and combat modes."""
 
 	def __init__(self, joy):
-		Game.game.AddUpdate(self, 20)	# relatively early update
-		Game.game.AddRender(self, 90)	# relatively late render (more on top)
-		Game.game.AddHandler(self, 20)	# relatively early event handler
+		Game.game.AddUpdate(self)
+		Game.game.AddRender(self)
+		Game.game.AddHandler(self)
 		self.fIsMagicAttackActive = False
 		
 		# Joystick tracking
@@ -55,7 +55,6 @@ class Hero:
 
 		self.surf = pygame.image.load(r"Oxygen.png")
 
-
 		# position, velocity, etc.
 
 		self.v = Vec.Vec(0, 0)
@@ -74,9 +73,12 @@ class Hero:
 		self.weapon = Weapon.Sword()	# BB (davidm) placeholder for now
 
 	def Kill(self):
-		Game.game.RemoveUpdate(self, 20)
-		Game.game.RemoveRender(self, 90)
-		Game.game.RemoveHandler(self, 20)
+		Game.game.RemoveUpdate(self)
+		Game.game.RemoveRender(self)
+		Game.game.RemoveHandler(self)
+
+	def Updatepri(self):
+		return Game.UpdatePri.HERO
 
 	def OnUpdate(self):
 		if Game.game.Mode() == Game.Mode.COMBAT:
@@ -165,6 +167,9 @@ class Hero:
 			
 		self.UpdateAttackMagic()
 			
+	def Handlerpri(self):
+		return Game.HandlerPri.HERO
+
 	def FHandleEvent(self, event):
 		if Game.game.Mode() == Game.Mode.COMBAT:
 
@@ -202,6 +207,9 @@ class Hero:
 				return True
 
 		return False
+
+	def Renderpri(self):
+		return Game.RenderPri.HERO
 
 	def OnRender(self, surfScreen):
 		if Game.game.Mode() == Game.Mode.WORLDMAP:

--- a/Menu.py
+++ b/Menu.py
@@ -48,9 +48,9 @@ class Menu:
 	""" game, etc."""
 
 	def __init__(self):
-		Game.game.AddUpdate(self, 10)	# relatively early update
-		Game.game.AddRender(self, 100)	# relatively late render (more on top)
-		Game.game.AddHandler(self, 10)	# relatively early event handler
+		Game.game.AddUpdate(self)
+		Game.game.AddRender(self)
+		Game.game.AddHandler(self)
 
 		self.m_lMd = []
 
@@ -97,6 +97,9 @@ class Menu:
 
 		Game.game.OnNewGame(strWorld)
 
+	def Updatepri(self):
+		return Game.UpdatePri.MENU
+
 	def OnUpdate(self):
 
 		# BB (davidm) unfortunate to have some menu actions happen in FHandleEvent
@@ -127,6 +130,9 @@ class Menu:
 
 		return
 
+	def Handlerpri(self):
+		return Game.HandlerPri.MENU
+
 	def FHandleEvent(self, event):
 		if event.type != pygame.KEYDOWN:
 			return False
@@ -150,6 +156,9 @@ class Menu:
 			self.m_lMd[-1].OnNavOk()
 
 		return True
+
+	def Renderpri(self):
+		return Game.RenderPri.MENU
 
 	def OnRender(self, surfScreen):
 		if Game.game.Mode() != Game.Mode.MENU:

--- a/Npc.py
+++ b/Npc.py
@@ -17,21 +17,27 @@ class Npc:
 	""" and quest givers, etc."""
 
 	def __init__(self):
-		Game.game.AddUpdate(self, 30)	# relatively early update
-		Game.game.AddRender(self, 80)	# relatively late render (more on top)
+		Game.game.AddUpdate(self)
+		Game.game.AddRender(self)
 
 		self.pos = Vec.Vec(0,0)			# location in the world
 		self.surf = None				# surface to render onto the screen
 
 	def Kill(self):
 		Game.game.RemoveNpc(self)
-		Game.game.RemoveUpdate(self, 30)
-		Game.game.RemoveRender(self, 80)
+		Game.game.RemoveUpdate(self)
+		Game.game.RemoveRender(self)
+
+	def Updatepri(self):
+		return Game.UpdatePri.NPC
 
 	def OnUpdate(self):
 		# NOTE (davidm) no default behavior here
 
 		pass
+
+	def Renderpri(self):
+		return Game.RenderPri.NPC
 
 	def OnRender(self, surfScreen):
 		if Game.game.Mode() == Game.Mode.WORLDMAP:
@@ -259,18 +265,24 @@ class Fireball():
 		self.pos = posStart
 		self.posEnd = posEnd
 		self.surf = pygame.image.load(r"Fiyaball.png")
-		Game.game.AddUpdate(self, 30)
-		Game.game.AddRender(self, 95)
+		Game.game.AddUpdate(self)
+		Game.game.AddRender(self)
 	
+	def Renderpri(self):
+		return Game.RenderPri.FIREBALL
+
 	def OnRender(self, surfScreen):
 		surfScreen.blit(self.surf, (int(self.pos.x), int(self.pos.y)))
 	
+	def Updatepri(self):
+		return Game.UpdatePri.FIREBALL
+
 	def OnUpdate(self):
 		self.UpdateMove()
 	
 	def Kill(self):
-		Game.game.RemoveUpdate(self, 30)
-		Game.game.RemoveRender(self, 95)
+		Game.game.RemoveUpdate(self)
+		Game.game.RemoveRender(self)
 	
 	def	UpdateMove(self):
 		hero = Game.game.LHero()[0]

--- a/World.py
+++ b/World.py
@@ -43,8 +43,8 @@ class World:
 
 	def MakeActive(self):
 		Game.game.SetWorld(self)
-		Game.game.AddUpdate(self, 90)	# relatively late update
-		Game.game.AddRender(self, 10)	# relatively early render (more on bottom)
+		Game.game.AddUpdate(self)
+		Game.game.AddRender(self)
 
 		# Chose randomized starting locations for the heroes
 
@@ -64,8 +64,11 @@ class World:
 	def MakeInactive(self):
 		if Game.game.World() == self:
 			Game.game.SetWorld(None)
-		Game.game.RemoveUpdate(self, 90)
-		Game.game.RemoveRender(self, 10)
+		Game.game.RemoveUpdate(self)
+		Game.game.RemoveRender(self)
+
+	def Updatepri(self):
+		return Game.UpdatePri.WORLD
 
 	def OnUpdate(self):
 		if Game.game.Mode() != Game.Mode.WORLDMAP:
@@ -115,6 +118,9 @@ class World:
 
 	def LMemberFromGroup(self, strGroup):
 		return self.mpGroupMembers.get(strGroup, [])
+
+	def Renderpri(self):
+		return Game.RenderPri.WORLD
 
 	def OnRender(self, surfScreen):
 		if Game.game.Mode() == Game.Mode.COMBAT:


### PR DESCRIPTION
Converted from silly number-based scheme to a set of Enums in Game.py which just list out the various categories in order. Makes maintenance much easier, and cleans up the Add/Remove interfaces a bit, at the cost of requiring two functions to operate in a given system (e.g., OnX and Xpri functions are now needed). This model should be much easier to maintain moving forward, at the marginal cost of requiring the addition of an enum type to each of the categories that an new object participates in.