### PR TITLE
Added accessor and tracking for start world

### DIFF
--- a/Game.py
+++ b/Game.py
@@ -107,7 +107,8 @@ class Game:
 		self.surfScreen = None		# area where everything is drawn
 		self.lJoy = []				# joysticks we've found
 
-		self.m_mode = Mode.MENU
+		self.m_mode = Mode.MENU			# mode we're in
+		self.m_strWorldNewGame = None	# what was the last new game world
 
 	def AddUpdate(self, obj):
 		"""Add obj to the priority list of objects to update.  obj is expected
@@ -229,6 +230,8 @@ class Game:
 	def OnNewGame(self, strWorld):
 		"""Clears objects and internal state and makes a new game start at the world map"""
 
+		self.m_strWorldNewGame = strWorld
+
 		for npc in self.lNpc:
 			npc.Kill()
 
@@ -265,6 +268,10 @@ class Game:
 		# exit out of the menu and set it were the player is in control and can walk around
 		self.SetMode(Mode.WORLDMAP)
 		
+	def StrWorldNewGameLast(self):
+		"""Returns the last new game world used, suitable for passing to OnNewGame, etc."""
+
+		return self.m_strWorldNewGame
 
 	def Run(self):
 


### PR DESCRIPTION
In order to be able to reset the game (say when the hero dies) we need to know what world to warp back into via OnNewGame. We now track that so that it's available for use.