### PR TITLE
Added support for auto boss key

### DIFF
--- a/Npc.py
+++ b/Npc.py
@@ -327,17 +327,15 @@ class Boss(Pattroler):
 		self.hpCur = self.hpMax
 		self.tickAttack = 0
 		self.tickAnimate = 0
-		Game.game.AddUpdate(self)
-		Game.game.AddRender(self)
 		self.fIsStage2 = False
 		self.fIsPrimed = False
-		self.surf1 = pygame.image.load(r"worker1.png")
-		self.surf2 = pygame.image.load(r"worker2.png")
-		self.surf3 = pygame.image.load(r"worker3.png")
-		self.surf4 = pygame.image.load(r"worker4.png")
-		self.surf5 = pygame.image.load(r"worker5.png")
-		self.surf6 = pygame.image.load(r"worker6.png")
-		self.surfDef = pygame.image.load(r"workerdef.png")
+		self.surf1 = pygame.image.load(r"Worker1.png")
+		self.surf2 = pygame.image.load(r"Worker2.png")
+		self.surf3 = pygame.image.load(r"Worker3.png")
+		self.surf4 = pygame.image.load(r"Worker4.png")
+		self.surf5 = pygame.image.load(r"Worker5.png")
+		self.surf6 = pygame.image.load(r"Worker6.png")
+		self.surfDef = pygame.image.load(r"Workerdef.png")
 		self.surf = self.surfDef
 	
 	def OnUpdate(self):
@@ -401,3 +399,15 @@ class Boss(Pattroler):
 		fire = Fireball(self.pos, hero.pos)
 		self.tickAttack = tickCur
 		
+	def Kill(self):
+		"""Add a boss key item to the hero's inventory upon death"""
+
+		# Add item to hero inventory; position at hero so we can update for auto-collect
+
+		hero = Game.game.LHero()[0]
+		itemKey = Item.Item(Game.game.World(), { 'tag': 'boss-key' }, hero.pos)
+		itemKey.OnUpdate()
+
+		# Run superclass behavior
+
+		super().Kill()


### PR DESCRIPTION
When a boss class object is killed, it now automatically adds an item to the hero's inventory with the boss-key tag. We should be set therefore to make various other things in the world respond appropriately such as doors after the boss has been defeated.

Also fixed a bug where the boss was getting to update and render twice each frame (!!) so we may need to adjust some timing numbers again.